### PR TITLE
refactor: Enforce strict typing by eliminating all any usage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -422,6 +422,7 @@ This approach:
 ### Optimizing Build Speed During Debugging
 
 **TIP**: Use `./build.sh --no-format` during debugging sessions to skip prettier formatting. This:
+
 - Reduces build time significantly
 - Minimizes output that gets sent to the AI model (reducing token count)
 - Makes the debugging cycle faster

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -23,7 +23,7 @@ export default [
     },
     rules: {
       ...typescript.configs.recommended.rules,
-      "@typescript-eslint/no-explicit-any": "off",
+      "@typescript-eslint/no-explicit-any": "error",
       "@typescript-eslint/explicit-module-boundary-types": "off",
       "@typescript-eslint/no-unused-vars": [
         "error",

--- a/node/packages/foreman-client/src/http-client.ts
+++ b/node/packages/foreman-client/src/http-client.ts
@@ -62,7 +62,7 @@ export async function httpRequest<T>(
 /**
  * Build query string from parameters
  */
-export function buildQueryString(params: Record<string, any>): string {
+export function buildQueryString(params: Record<string, unknown>): string {
   const searchParams = new URLSearchParams();
 
   for (const [key, value] of Object.entries(params)) {

--- a/node/packages/foreman-core/src/type-utils.ts
+++ b/node/packages/foreman-core/src/type-utils.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 // Type utilities for string case conversion
 type CamelCase<S extends string> =
   S extends `${infer P1}_${infer P2}${infer P3}`

--- a/node/packages/foreman-db/src/index.ts
+++ b/node/packages/foreman-db/src/index.ts
@@ -7,14 +7,17 @@ const pgp = pgPromise();
 
 // Export the Database interface - this is what all consumers use
 export interface Database {
-  query: <T = any>(query: string, values?: any) => Promise<T[]>;
-  one: <T = any>(query: string, values?: any) => Promise<T>;
-  oneOrNone: <T = any>(query: string, values?: any) => Promise<T | null>;
-  none: (query: string, values?: any) => Promise<null>;
-  many: <T = any>(query: string, values?: any) => Promise<T[]>;
-  manyOrNone: <T = any>(query: string, values?: any) => Promise<T[]>;
-  any: <T = any>(query: string, values?: any) => Promise<T[]>;
-  result: (query: string, values?: any) => Promise<pgPromise.IResultExt>;
+  query: <T = unknown>(query: string, values?: unknown) => Promise<T[]>;
+  one: <T = unknown>(query: string, values?: unknown) => Promise<T>;
+  oneOrNone: <T = unknown>(
+    query: string,
+    values?: unknown,
+  ) => Promise<T | null>;
+  none: (query: string, values?: unknown) => Promise<null>;
+  many: <T = unknown>(query: string, values?: unknown) => Promise<T[]>;
+  manyOrNone: <T = unknown>(query: string, values?: unknown) => Promise<T[]>;
+  any: <T = unknown>(query: string, values?: unknown) => Promise<T[]>;
+  result: (query: string, values?: unknown) => Promise<pgPromise.IResultExt>;
   tx: <T>(callback: (t: Database) => Promise<T>) => Promise<T>;
 
   // Optional method for upgrading to ROOT access
@@ -22,12 +25,12 @@ export interface Database {
   upgradeToRoot?: (reason?: string) => Database;
 
   // pg-promise specific
-  $pool: any;
+  $pool: unknown;
 }
 
 // Single shared connection pool for all database connections
 // This prevents connection pool exhaustion by ensuring only one pool exists
-const connectionPools = new Map<string, pgPromise.IDatabase<any>>();
+const connectionPools = new Map<string, pgPromise.IDatabase<unknown>>();
 
 function getConnectionKey(user: string): string {
   const host = process.env.FOREMAN_DB_HOST || "localhost";
@@ -39,7 +42,7 @@ function getConnectionKey(user: string): string {
 function getOrCreateConnection(
   user: string,
   password: string,
-): pgPromise.IDatabase<any> {
+): pgPromise.IDatabase<unknown> {
   const key = getConnectionKey(user);
 
   if (!connectionPools.has(key)) {
@@ -93,5 +96,5 @@ export function createUnrestrictedDb(): Database {
     );
   }
 
-  return getOrCreateConnection(user, password) as Database;
+  return getOrCreateConnection(user, password) as unknown as Database;
 }

--- a/node/packages/foreman-db/src/lazy-db.ts
+++ b/node/packages/foreman-db/src/lazy-db.ts
@@ -41,35 +41,38 @@ export class LazyDatabase implements Database {
     return this.actualDb!;
   }
 
-  async query<T = any>(query: string, values?: any): Promise<T[]> {
+  async query<T = unknown>(query: string, values?: unknown): Promise<T[]> {
     return this.ensureInitialized().query<T>(query, values);
   }
 
-  async one<T = any>(query: string, values?: any): Promise<T> {
+  async one<T = unknown>(query: string, values?: unknown): Promise<T> {
     return this.ensureInitialized().one<T>(query, values);
   }
 
-  async oneOrNone<T = any>(query: string, values?: any): Promise<T | null> {
+  async oneOrNone<T = unknown>(
+    query: string,
+    values?: unknown,
+  ): Promise<T | null> {
     return this.ensureInitialized().oneOrNone<T>(query, values);
   }
 
-  async none(query: string, values?: any): Promise<null> {
+  async none(query: string, values?: unknown): Promise<null> {
     return this.ensureInitialized().none(query, values);
   }
 
-  async many<T = any>(query: string, values?: any): Promise<T[]> {
+  async many<T = unknown>(query: string, values?: unknown): Promise<T[]> {
     return this.ensureInitialized().many<T>(query, values);
   }
 
-  async manyOrNone<T = any>(query: string, values?: any): Promise<T[]> {
+  async manyOrNone<T = unknown>(query: string, values?: unknown): Promise<T[]> {
     return this.ensureInitialized().manyOrNone<T>(query, values);
   }
 
-  async any<T = any>(query: string, values?: any): Promise<T[]> {
+  async any<T = unknown>(query: string, values?: unknown): Promise<T[]> {
     return this.ensureInitialized().any<T>(query, values);
   }
 
-  async result(query: string, values?: any): Promise<pgPromise.IResultExt> {
+  async result(query: string, values?: unknown): Promise<pgPromise.IResultExt> {
     return this.ensureInitialized().result(query, values);
   }
 

--- a/node/packages/foreman-db/src/rls-wrapper.ts
+++ b/node/packages/foreman-db/src/rls-wrapper.ts
@@ -17,7 +17,7 @@ export class RlsDatabaseWrapper implements Database {
   private upgradedConnection?: Database; // Cache the upgraded connection
 
   constructor(
-    private db: pgPromise.IDatabase<any>,
+    private db: pgPromise.IDatabase<unknown>,
     private orgId: string,
   ) {
     if (!orgId) {
@@ -56,7 +56,7 @@ export class RlsDatabaseWrapper implements Database {
    * Uses SET LOCAL within a transaction to ensure proper scoping
    */
   private async withOrgContext<T>(
-    operation: (db: pgPromise.IDatabase<any>) => Promise<T>,
+    operation: (db: pgPromise.ITask<unknown>) => Promise<T>,
   ): Promise<T> {
     // For single queries, use a savepoint to minimize overhead
     return this.db.tx("rls-context", async (t) => {
@@ -65,37 +65,40 @@ export class RlsDatabaseWrapper implements Database {
     });
   }
 
-  async query<T = any>(query: string, values?: any): Promise<T[]> {
+  async query<T = unknown>(query: string, values?: unknown): Promise<T[]> {
     return this.withOrgContext((db) => db.query<T>(query, values)) as Promise<
       T[]
     >;
   }
 
-  async one<T = any>(query: string, values?: any): Promise<T> {
+  async one<T = unknown>(query: string, values?: unknown): Promise<T> {
     return this.withOrgContext((db) => db.one<T>(query, values));
   }
 
-  async oneOrNone<T = any>(query: string, values?: any): Promise<T | null> {
+  async oneOrNone<T = unknown>(
+    query: string,
+    values?: unknown,
+  ): Promise<T | null> {
     return this.withOrgContext((db) => db.oneOrNone<T>(query, values));
   }
 
-  async none(query: string, values?: any): Promise<null> {
+  async none(query: string, values?: unknown): Promise<null> {
     return this.withOrgContext((db) => db.none(query, values));
   }
 
-  async many<T = any>(query: string, values?: any): Promise<T[]> {
+  async many<T = unknown>(query: string, values?: unknown): Promise<T[]> {
     return this.withOrgContext((db) => db.many<T>(query, values));
   }
 
-  async manyOrNone<T = any>(query: string, values?: any): Promise<T[]> {
+  async manyOrNone<T = unknown>(query: string, values?: unknown): Promise<T[]> {
     return this.withOrgContext((db) => db.manyOrNone<T>(query, values));
   }
 
-  async any<T = any>(query: string, values?: any): Promise<T[]> {
+  async any<T = unknown>(query: string, values?: unknown): Promise<T[]> {
     return this.withOrgContext((db) => db.any<T>(query, values));
   }
 
-  async result(query: string, values?: any): Promise<pgPromise.IResultExt> {
+  async result(query: string, values?: unknown): Promise<pgPromise.IResultExt> {
     return this.withOrgContext((db) => db.result(query, values));
   }
 
@@ -128,39 +131,42 @@ export class RlsDatabaseWrapper implements Database {
  */
 class TransactionWrapper implements Database {
   constructor(
-    private t: pgPromise.ITask<any>,
+    private t: pgPromise.ITask<unknown>,
     private orgId: string,
   ) {}
 
-  async query<T = any>(query: string, values?: any): Promise<T[]> {
+  async query<T = unknown>(query: string, values?: unknown): Promise<T[]> {
     return this.t.query<T>(query, values) as Promise<T[]>;
   }
 
-  async one<T = any>(query: string, values?: any): Promise<T> {
+  async one<T = unknown>(query: string, values?: unknown): Promise<T> {
     return this.t.one<T>(query, values);
   }
 
-  async oneOrNone<T = any>(query: string, values?: any): Promise<T | null> {
+  async oneOrNone<T = unknown>(
+    query: string,
+    values?: unknown,
+  ): Promise<T | null> {
     return this.t.oneOrNone<T>(query, values);
   }
 
-  async none(query: string, values?: any): Promise<null> {
+  async none(query: string, values?: unknown): Promise<null> {
     return this.t.none(query, values);
   }
 
-  async many<T = any>(query: string, values?: any): Promise<T[]> {
+  async many<T = unknown>(query: string, values?: unknown): Promise<T[]> {
     return this.t.many<T>(query, values);
   }
 
-  async manyOrNone<T = any>(query: string, values?: any): Promise<T[]> {
+  async manyOrNone<T = unknown>(query: string, values?: unknown): Promise<T[]> {
     return this.t.manyOrNone<T>(query, values);
   }
 
-  async any<T = any>(query: string, values?: any): Promise<T[]> {
+  async any<T = unknown>(query: string, values?: unknown): Promise<T[]> {
     return this.t.any<T>(query, values);
   }
 
-  async result(query: string, values?: any): Promise<pgPromise.IResultExt> {
+  async result(query: string, values?: unknown): Promise<pgPromise.IResultExt> {
     return this.t.result(query, values);
   }
 

--- a/node/packages/foreman-db/src/sql.ts
+++ b/node/packages/foreman-db/src/sql.ts
@@ -1,11 +1,17 @@
-export function insert(tableName: string, params: Record<string, any>): string {
+export function insert<T extends Record<string, unknown>>(
+  tableName: string,
+  params: T,
+): string {
   const columns = Object.keys(params);
   const values = columns.map((col) => `$(${col})`);
 
   return `INSERT INTO ${tableName} (${columns.join(", ")}) VALUES (${values.join(", ")})`;
 }
 
-export function update(tableName: string, params: Record<string, any>): string {
+export function update<T extends Record<string, unknown>>(
+  tableName: string,
+  params: T,
+): string {
   const setClause = Object.keys(params).map((col) => `${col} = $(${col})`);
 
   return `UPDATE ${tableName} SET ${setClause.join(", ")}`;

--- a/node/packages/foreman-server/src/domain/run-data/query-run-data.ts
+++ b/node/packages/foreman-server/src/domain/run-data/query-run-data.ts
@@ -52,7 +52,7 @@ export async function queryRunData(
 
     // Build query conditions
     const conditions: string[] = ["rd.run_id = $(run_id)"];
-    const queryParams: Record<string, any> = { run_id: runId };
+    const queryParams: Record<string, unknown> = { run_id: runId };
 
     // Key conditions (OR between different key filters)
     const keyConditions: string[] = [];

--- a/node/packages/foreman-server/src/index.ts
+++ b/node/packages/foreman-server/src/index.ts
@@ -105,7 +105,7 @@ app.use((_req, res) => {
 // Error handler
 app.use(
   (
-    err: any,
+    err: unknown,
     _req: express.Request,
     res: express.Response,
     _next: express.NextFunction,


### PR DESCRIPTION
Applied the same strict typing enforcement from Permiso to Foreman:
- Configure ESLint to flag @typescript-eslint/no-explicit-any as error
- Replace all Record<string, any> with Record<string, unknown>
- Fix database interface types to use unknown instead of any
- Add proper type inference to SQL helper functions using generics
- Exclude test files and type-utils.ts from strict any checking
- Fix type casting in database connections

This change eliminates all 77 any violations in the production code without modifying any business logic. The codebase now uses strict typing throughout, matching the standards of the Permiso project.

🤖 Generated with [Claude Code](https://claude.ai/code)