### PR TITLE
refactor: Convert timestamps from PostgreSQL timestamp to bigint epoc…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,6 +7,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with th
 ### NEVER ACT WITHOUT EXPLICIT USER APPROVAL
 
 **YOU MUST ALWAYS ASK FOR PERMISSION BEFORE:**
+
 - Making architectural decisions or changes
 - Implementing new features or functionality
 - Modifying APIs, interfaces, or data structures
@@ -18,6 +19,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with th
 ### FINISH DISCUSSIONS BEFORE WRITING CODE
 
 **IMPORTANT**: When the user asks a question or you're in the middle of a discussion, DO NOT jump to writing code. Always:
+
 1. **Complete the discussion first** - Understand the problem fully
 2. **Analyze and explain** - Work through the issue verbally
 3. **Get confirmation** - Ensure the user agrees with the approach
@@ -32,6 +34,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with th
 ### First Steps When Starting a Session
 
 When you begin working on this project, you MUST:
+
 1. **Read this entire CLAUDE.md file** to understand the project structure and conventions
 2. **Check for ongoing tasks in `.todos/` directory** - Look for any in-progress task files
 3. **Read the key documentation files** in this order:
@@ -77,6 +80,7 @@ This guide helps AI assistants work effectively with the Foreman codebase. For p
 ### Greenfield Development Context
 
 **IMPORTANT**: Foreman is a greenfield project with no legacy constraints:
+
 - **No backward compatibility concerns** - No existing deployments or users to migrate
 - **No legacy code patterns** - All code should follow current best practices without compromise
 - **No migration paths needed** - Database schemas, APIs, and data structures can be designed optimally
@@ -89,6 +93,7 @@ This means: Focus on clean, optimal implementations without worrying about exist
 ### Documentation & Code Principles
 
 **Documentation Guidelines:**
+
 - Write as if the spec was designed from the beginning, not evolved over time
 - Avoid phrases like "now allows", "changed from", "previously was"
 - Present features and constraints as inherent design decisions
@@ -97,6 +102,7 @@ This means: Focus on clean, optimal implementations without worrying about exist
 - Keep README.md as single source of truth
 
 **Code Principles:**
+
 - **NO BACKWARDS COMPATIBILITY** - Do not write backwards compatibility code
 - **NO CLASSES** - Export functions from modules only, use explicit dependency injection
 - **NO DYNAMIC IMPORTS** - Always use static imports, never `await import()` or `import()`
@@ -106,13 +112,16 @@ This means: Focus on clean, optimal implementations without worrying about exist
 ## Core Architecture Principles
 
 ### 1. ID-Only Queue Pattern
+
 - **NEVER** store task data in queues (BullMQ, SQS, etc.)
 - **ALWAYS** store all task data in PostgreSQL
 - Queues contain only task IDs
 - Workers fetch full data from Foreman before processing
 
 ### 2. Security: Never Use npx
+
 **CRITICAL SECURITY REQUIREMENT**: NEVER use `npx` for any commands. This poses grave security risks by executing arbitrary code.
+
 - **ALWAYS use exact dependency versions** in package.json
 - **ALWAYS use local node_modules binaries** (e.g., `prettier`, `mocha`, `http-server`)
 - **NEVER use `npx prettier`** - use `prettier` from local dependencies
@@ -121,6 +130,7 @@ This means: Focus on clean, optimal implementations without worrying about exist
 **Exception**: Only acceptable `npx` usage is for one-time project initialization when explicitly setting up new projects.
 
 ### 3. REST API Design
+
 - RESTful endpoints (no GraphQL)
 - JSON request/response bodies
 - Standard HTTP status codes
@@ -128,6 +138,7 @@ This means: Focus on clean, optimal implementations without worrying about exist
 - Consistent error response format
 
 ### 4. Database Conventions
+
 - **PostgreSQL** with **Knex.js** for migrations, **pg-promise** for data access (NO ORMs)
 - Table names: **singular** and **snake_case** (e.g., `run`, `task`, `run_data`)
 - TypeScript: **camelCase** for all variables/properties
@@ -137,11 +148,13 @@ This means: Focus on clean, optimal implementations without worrying about exist
 - **Type-safe Queries**: All queries use `db.one<XxxDbRow>()` with explicit type parameters
 
 **Query Optimization Guidelines**:
+
 - **Prefer simple separate queries over complex joins** when it only saves 1-3 database calls
 - **Use joins only to prevent N+1 query problems** (e.g., fetching data for many items in a loop)
 - **Prioritize code simplicity and readability** over minor performance optimizations
 
 ### 5. ESM Modules
+
 - All imports MUST include `.js` extension: `import { foo } from "./bar.js"`
 - TypeScript configured for `"module": "NodeNext"`
 - Type: `"module"` in all package.json files
@@ -227,12 +240,14 @@ npm run test:client:grep -- "fetch workflow"  # Only client tests
 ### Git Workflow
 
 **CRITICAL GIT SAFETY RULES**:
+
 1. **NEVER use `git push --force` or `git push -f`** - Force pushing destroys history
 2. **ALL git push commands require EXPLICIT user authorization**
 3. **Use revert commits instead of force push** - To undo changes, create revert commits
 4. **If you need to overwrite remote**, explain consequences and get explicit confirmation
 
 **IMPORTANT**: NEVER commit or push changes without explicit user instruction
+
 - Only run `git add`, `git commit`, or `git push` when the user explicitly asks
 - Common explicit instructions include: "commit", "push", "commit and push", "save to git"
 - Always wait for user approval before making any git operations
@@ -240,6 +255,7 @@ npm run test:client:grep -- "fetch workflow"  # Only client tests
 **NEW BRANCH REQUIREMENT**: ALL changes must be made on a new feature branch, never directly on main.
 
 When the user asks you to commit and push:
+
 1. Run `./scripts/format-all.sh` to format all files with Prettier
 2. Run `./scripts/lint-all.sh` to ensure code passes linting
 3. Follow the git commit guidelines in the main Claude system prompt
@@ -345,7 +361,9 @@ router.post("/", authenticate, async (req, res) => {
 const result = await foreman.createTask({
   runId: "run-123",
   type: "process",
-  inputData: { /* data */ },
+  inputData: {
+    /* data */
+  },
 });
 
 if (!result.success) {
@@ -359,12 +377,14 @@ const task = result.data;
 ## Key Data Model Concepts
 
 ### Runs
+
 - Top-level execution context
 - Contains input/output data and metadata
 - Tracks overall status and metrics
 - Organization-scoped for multi-tenancy
 
 ### Tasks
+
 - Individual units of work within a run
 - Hierarchical (parent-child relationships)
 - Status lifecycle: pending → queued → running → completed/failed
@@ -372,6 +392,7 @@ const task = result.data;
 - Links to external queue job IDs
 
 ### Run Data
+
 - Key-value storage for inter-task communication
 - Supports multiple values per key (no unique constraint)
 - Tags array for categorization and filtering
@@ -379,6 +400,7 @@ const task = result.data;
 - Tracks which task created each entry
 
 ### Authentication
+
 - Simple Bearer token validation
 - No database storage (fully trusted environment)
 - All authenticated users have full access
@@ -429,6 +451,7 @@ Benefits: Keeps analysis artifacts separate from source code, allows iterative w
 ### Build & Lint Workflow
 
 **ALWAYS follow this sequence:**
+
 1. Run `./scripts/lint-all.sh` first
 2. Run `./scripts/build.sh`
 3. **If build fails and you make changes**: You MUST run `./scripts/lint-all.sh` again before building
@@ -438,6 +461,7 @@ Benefits: Keeps analysis artifacts separate from source code, allows iterative w
 ## Common Development Tasks
 
 ### Adding a New Domain Entity
+
 1. Add types to `foreman-server/src/types.ts`
 2. Create migration in `/database/foreman/migrations/`
 3. Add mapper functions to `foreman-server/src/mappers.ts`
@@ -446,6 +470,7 @@ Benefits: Keeps analysis artifacts separate from source code, allows iterative w
 6. Update client in `foreman-client/src/index.ts`
 
 ### Adding a New API Endpoint
+
 1. Define request/response types
 2. Create Zod validation schemas
 3. Implement domain function with Result type
@@ -454,6 +479,7 @@ Benefits: Keeps analysis artifacts separate from source code, allows iterative w
 6. Document in `/docs/api.md`
 
 ### Database Changes
+
 1. Create migration: `npm run migrate:foreman:make your_migration_name`
 2. Edit migration file with up/down functions
 3. Run migration: `npm run migrate:foreman:latest` (only when asked)
@@ -462,6 +488,7 @@ Benefits: Keeps analysis artifacts separate from source code, allows iterative w
 ## API Response Formats
 
 ### Pagination
+
 All list endpoints return paginated results:
 
 ```typescript
@@ -476,12 +503,14 @@ All list endpoints return paginated results:
 ```
 
 ### Error Responses
+
 - 400: Invalid request data or validation errors
 - 401: Authentication required or invalid Bearer token
 - 404: Resource not found
 - 500: Internal server error
 
 Error format:
+
 ```json
 {
   "error": "Error message",
@@ -490,7 +519,9 @@ Error format:
 ```
 
 ### Run Data Query API
+
 The `GET /api/v1/runs/:runId/data` endpoint supports flexible querying:
+
 - `key`: Exact key match
 - `keys`: Multiple exact keys (comma-separated)
 - `keyStartsWith`: Key prefix match
@@ -509,7 +540,9 @@ The core principle of Foreman:
 
 ```typescript
 // 1. Create task with full data in Foreman
-const task = await foreman.createTask({ /* all data */ });
+const task = await foreman.createTask({
+  /* all data */
+});
 
 // 2. Queue ONLY the task ID
 await queue.add("process", { taskId: task.data.id });

--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ const results = await queryRunData(foremanConfig, run.data.id, {
 await updateRun(foremanConfig, run.data.id, {
   status: "completed",
   outputData: {
-    processedAt: new Date().toISOString(),
+    processedAt: Date.now(),
     totalAmount: 99.99,
   },
 });

--- a/docs/api.md
+++ b/docs/api.md
@@ -457,8 +457,8 @@ Response:
       "metadata": {
         /* metadata */
       },
-      "createdAt": "2024-01-01T00:00:00Z",
-      "updatedAt": "2024-01-01T00:00:00Z"
+      "createdAt": 1704067200000,
+      "updatedAt": 1704067200000
     }
   ],
   "pagination": {
@@ -638,7 +638,7 @@ Default rate limit: 100 requests per 15 minutes per Bearer token.
 
 ### Response Fields
 
-All timestamps include:
+All timestamps are epoch milliseconds (number type):
 
 - `createdAt` - When the resource was created
 - `updatedAt` - When the resource was last modified (for run and task)

--- a/node/packages/foreman-client/src/api-types.ts
+++ b/node/packages/foreman-client/src/api-types.ts
@@ -16,9 +16,10 @@ export type Run = {
   totalTasks: number;
   completedTasks: number;
   failedTasks: number;
-  createdAt: string;
-  startedAt?: string;
-  completedAt?: string;
+  createdAt: number;
+  updatedAt: number;
+  startedAt?: number;
+  completedAt?: number;
   durationMs?: number;
 };
 
@@ -57,10 +58,11 @@ export type Task = {
   metadata?: Record<string, unknown>;
   retryCount: number;
   maxRetries: number;
-  createdAt: string;
-  queuedAt?: string;
-  startedAt?: string;
-  completedAt?: string;
+  createdAt: number;
+  updatedAt: number;
+  queuedAt?: number;
+  startedAt?: number;
+  completedAt?: number;
   durationMs?: number;
   queueJobId?: string;
 };
@@ -103,8 +105,8 @@ export type RunData = {
   value: unknown;
   tags: string[];
   metadata?: Record<string, unknown>;
-  createdAt: string;
-  updatedAt: string;
+  createdAt: number;
+  updatedAt: number;
 };
 
 export type CreateRunDataInput = {

--- a/node/packages/foreman-db/src/index.ts
+++ b/node/packages/foreman-db/src/index.ts
@@ -4,6 +4,7 @@ export * as sql from "./sql.js";
 export { createLazyDb } from "./lazy-db.js";
 
 const pgp = pgPromise();
+pgp.pg.types.setTypeParser(20, (val: string) => parseInt(val, 10));
 
 // Export the Database interface - this is what all consumers use
 export interface Database {

--- a/node/packages/foreman-integration-tests/src/tests/run-data.test.ts
+++ b/node/packages/foreman-integration-tests/src/tests/run-data.test.ts
@@ -118,7 +118,7 @@ describe("Run Data API", () => {
 
   describe("GET /api/v1/runs/:runId/data", () => {
     beforeEach(async () => {
-      // Create some test data
+      // Create some test data with small delays to ensure different timestamps
       await client.post(`/api/v1/runs/${runId}/data`, {
         taskId,
         key: "user-data",
@@ -126,12 +126,18 @@ describe("Run Data API", () => {
         tags: ["user", "profile"],
       });
 
+      // Small delay to ensure different timestamp
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
       await client.post(`/api/v1/runs/${runId}/data`, {
         taskId,
         key: "config",
         value: { theme: "dark", lang: "en" },
         tags: ["config", "settings"],
       });
+
+      // Small delay to ensure different timestamp
+      await new Promise((resolve) => setTimeout(resolve, 10));
 
       await client.post(`/api/v1/runs/${runId}/data`, {
         taskId,
@@ -204,9 +210,7 @@ describe("Run Data API", () => {
       );
 
       expect(response.status).to.equal(200);
-      const dates = response.data.data.map((item: any) =>
-        new Date(item.createdAt).getTime(),
-      );
+      const dates = response.data.data.map((item: any) => item.createdAt);
 
       // Check if sorted in descending order
       for (let i = 1; i < dates.length; i++) {

--- a/node/packages/foreman-server/src/domain/run-data/create-run-data.ts
+++ b/node/packages/foreman-server/src/domain/run-data/create-run-data.ts
@@ -48,6 +48,7 @@ export async function createRunData(
       }
 
       const id = uuidv4();
+      const now = Date.now();
 
       // Insert run data (allows multiple entries per key)
       const params = {
@@ -59,8 +60,8 @@ export async function createRunData(
         value: input.value as Record<string, unknown>,
         tags: input.tags || [],
         metadata: input.metadata || null,
-        created_at: new Date(),
-        updated_at: new Date(),
+        created_at: now,
+        updated_at: now,
       };
 
       const row = await t.one<RunDataDbRow>(

--- a/node/packages/foreman-server/src/domain/run-data/update-run-data-tags.ts
+++ b/node/packages/foreman-server/src/domain/run-data/update-run-data-tags.ts
@@ -54,10 +54,10 @@ export async function updateRunDataTags(
       const row = await t.one<RunDataDbRow>(
         `UPDATE run_data
          SET tags = $(tags),
-             updated_at = NOW()
+             updated_at = $(updated_at)
          WHERE id = $(data_id)
          RETURNING *`,
-        { data_id: dataId, tags: newTags },
+        { data_id: dataId, tags: newTags, updated_at: Date.now() },
       );
 
       logger.info("Updated run data tags", {

--- a/node/packages/foreman-server/src/domain/run/create-run.ts
+++ b/node/packages/foreman-server/src/domain/run/create-run.ts
@@ -25,6 +25,7 @@ export async function createRun(
     }
 
     const id = uuidv4();
+    const now = Date.now();
 
     const params = {
       id,
@@ -32,7 +33,11 @@ export async function createRun(
       status: "pending",
       input_data: input.inputData as Record<string, unknown>,
       metadata: input.metadata || null,
-      created_at: new Date(),
+      total_tasks: 0,
+      completed_tasks: 0,
+      failed_tasks: 0,
+      created_at: now,
+      updated_at: now,
     };
 
     const row = await ctx.db.one<RunDbRow>(

--- a/node/packages/foreman-server/src/domain/run/update-run.ts
+++ b/node/packages/foreman-server/src/domain/run/update-run.ts
@@ -21,7 +21,10 @@ export async function updateRun(
   input: UpdateRunInput,
 ): Promise<Result<Run, Error>> {
   try {
-    const updateParams: Record<string, unknown> = {};
+    const now = Date.now();
+    const updateParams: Record<string, unknown> = {
+      updated_at: now,
+    };
     const additionalUpdates: string[] = [];
 
     if (input.status !== undefined) {
@@ -29,14 +32,14 @@ export async function updateRun(
 
       // Set started_at when transitioning to running
       if (input.status === "running") {
-        additionalUpdates.push("started_at = COALESCE(started_at, NOW())");
+        additionalUpdates.push(`started_at = COALESCE(started_at, ${now})`);
       }
 
       // Set completed_at and calculate duration when transitioning to terminal state
       if (["completed", "failed", "cancelled"].includes(input.status)) {
-        additionalUpdates.push("completed_at = NOW()");
+        updateParams.completed_at = now;
         additionalUpdates.push(
-          "duration_ms = EXTRACT(EPOCH FROM (NOW() - COALESCE(started_at, created_at))) * 1000",
+          `duration_ms = ${now} - COALESCE(started_at, created_at)`,
         );
       }
     }

--- a/node/packages/foreman-server/src/domain/task/create-task.ts
+++ b/node/packages/foreman-server/src/domain/task/create-task.ts
@@ -54,6 +54,7 @@ export async function createTask(
       }
 
       const id = uuidv4();
+      const now = Date.now();
 
       // Create task
       const params = {
@@ -65,8 +66,10 @@ export async function createTask(
         status: "pending",
         input_data: input.inputData as Record<string, unknown>,
         metadata: input.metadata || null,
+        retry_count: 0,
         max_retries: input.maxRetries || 3,
-        created_at: new Date(),
+        created_at: now,
+        updated_at: now,
       };
 
       const row = await t.one<TaskDbRow>(
@@ -76,8 +79,8 @@ export async function createTask(
 
       // Update run task count
       await t.none(
-        `UPDATE run SET total_tasks = total_tasks + 1 WHERE id = $(run_id)`,
-        { run_id: input.runId },
+        `UPDATE run SET total_tasks = total_tasks + 1, updated_at = $(now) WHERE id = $(run_id)`,
+        { run_id: input.runId, now: Date.now() },
       );
 
       logger.info("Created task", { id, runId: input.runId, type: input.type });

--- a/node/packages/foreman-server/src/mappers.ts
+++ b/node/packages/foreman-server/src/mappers.ts
@@ -32,7 +32,7 @@ export function mapRunFromDb(row: RunDbRow): Run {
     updatedAt: row.updated_at,
     startedAt: row.started_at ?? undefined,
     completedAt: row.completed_at ?? undefined,
-    durationMs: row.duration_ms ? parseInt(row.duration_ms) : undefined,
+    durationMs: row.duration_ms ?? undefined,
   };
 }
 
@@ -61,8 +61,7 @@ export function mapRunToDb(run: Partial<Run>): Partial<RunDbRow> {
   if (run.updatedAt !== undefined) dbRow.updated_at = run.updatedAt;
   if (run.startedAt !== undefined) dbRow.started_at = run.startedAt;
   if (run.completedAt !== undefined) dbRow.completed_at = run.completedAt;
-  if (run.durationMs !== undefined)
-    dbRow.duration_ms = run.durationMs.toString();
+  if (run.durationMs !== undefined) dbRow.duration_ms = run.durationMs;
 
   return dbRow;
 }
@@ -89,7 +88,7 @@ export function mapTaskFromDb(row: TaskDbRow): Task {
     queuedAt: row.queued_at ?? undefined,
     startedAt: row.started_at ?? undefined,
     completedAt: row.completed_at ?? undefined,
-    durationMs: row.duration_ms ? parseInt(row.duration_ms) : undefined,
+    durationMs: row.duration_ms ?? undefined,
     queueJobId: row.queue_job_id ?? undefined,
   };
 }
@@ -121,8 +120,7 @@ export function mapTaskToDb(task: Partial<Task>): Partial<TaskDbRow> {
   if (task.queuedAt !== undefined) dbRow.queued_at = task.queuedAt;
   if (task.startedAt !== undefined) dbRow.started_at = task.startedAt;
   if (task.completedAt !== undefined) dbRow.completed_at = task.completedAt;
-  if (task.durationMs !== undefined)
-    dbRow.duration_ms = task.durationMs.toString();
+  if (task.durationMs !== undefined) dbRow.duration_ms = task.durationMs;
   if (task.queueJobId !== undefined) dbRow.queue_job_id = task.queueJobId;
 
   return dbRow;

--- a/node/packages/foreman-server/src/types.ts
+++ b/node/packages/foreman-server/src/types.ts
@@ -32,10 +32,10 @@ export type Run = {
   totalTasks: number;
   completedTasks: number;
   failedTasks: number;
-  createdAt: Date;
-  updatedAt: Date;
-  startedAt?: Date;
-  completedAt?: Date;
+  createdAt: number;
+  updatedAt: number;
+  startedAt?: number;
+  completedAt?: number;
   durationMs?: number;
 };
 
@@ -53,11 +53,11 @@ export type Task = {
   metadata?: Record<string, unknown>;
   retryCount: number;
   maxRetries: number;
-  createdAt: Date;
-  updatedAt: Date;
-  queuedAt?: Date;
-  startedAt?: Date;
-  completedAt?: Date;
+  createdAt: number;
+  updatedAt: number;
+  queuedAt?: number;
+  startedAt?: number;
+  completedAt?: number;
   durationMs?: number;
   queueJobId?: string;
 };
@@ -72,8 +72,8 @@ export type RunData = {
   value: unknown;
   tags: string[];
   metadata?: Record<string, unknown>;
-  createdAt: Date;
-  updatedAt: Date;
+  createdAt: number;
+  updatedAt: number;
 };
 
 // Note: API keys are validated in middleware without database storage
@@ -91,11 +91,11 @@ export type RunDbRow = {
   total_tasks: number;
   completed_tasks: number;
   failed_tasks: number;
-  created_at: Date;
-  updated_at: Date;
-  started_at: Date | null;
-  completed_at: Date | null;
-  duration_ms: string | null; // bigint comes as string
+  created_at: number;
+  updated_at: number;
+  started_at: number | null;
+  completed_at: number | null;
+  duration_ms: number | null;
 };
 
 export type TaskDbRow = {
@@ -111,12 +111,12 @@ export type TaskDbRow = {
   metadata: unknown | null;
   retry_count: number;
   max_retries: number;
-  created_at: Date;
-  updated_at: Date;
-  queued_at: Date | null;
-  started_at: Date | null;
-  completed_at: Date | null;
-  duration_ms: string | null; // bigint comes as string
+  created_at: number;
+  updated_at: number;
+  queued_at: number | null;
+  started_at: number | null;
+  completed_at: number | null;
+  duration_ms: number | null;
   queue_job_id: string | null;
 };
 
@@ -129,8 +129,8 @@ export type RunDataDbRow = {
   value: unknown;
   tags: string[];
   metadata: unknown | null;
-  created_at: Date;
-  updated_at: Date;
+  created_at: number;
+  updated_at: number;
 };
 
 // API request/response types


### PR DESCRIPTION
…h milliseconds

- Remove all default values from database schema (must be supplied by client)
- Change all timestamp columns to bigint for storing epoch milliseconds
- Update TypeScript types from Date to number for all timestamps
- Add explicit timestamp generation using Date.now() in domain code
- Configure pg-promise type parser for bigint values
- Update API documentation to show epoch milliseconds instead of ISO strings
- Update database documentation to reflect bigint schema

BREAKING CHANGE: All timestamps are now stored as epoch milliseconds (bigint) instead of PostgreSQL timestamps. API consumers must send/receive timestamps as numbers rather than ISO date strings.

🤖 Generated with [Claude Code](https://claude.ai/code)